### PR TITLE
Add Polish translation

### DIFF
--- a/addon/doc/pl/readme.md
+++ b/addon/doc/pl/readme.md
@@ -1,0 +1,552 @@
+# Sklep z dodatkami dla NVDA
+
+> **Ważna informacja dla testerów wersji beta:**
+> Jeśli testowałeś dodatek **TiendaNVDA_Modern**, odinstaluj go przed instalacją tej wersji. Tamta wersja była wersją testową i beta, więc nie powinna działać równocześnie z tą wersją końcową. Aby ją odinstalować, przejdź do menu NVDA -> Narzędzia -> Sklep z dodatkami, wybierz "TiendaNVDA_Modern" i usuń go. Następnie uruchom NVDA ponownie i dopiero zainstaluj tę wersję.
+
+Ujednolicony sklep dodatków dla NVDA: łączy **sklep społeczności hiszpańskojęzycznej (NVDA.ES)** oraz **oficjalny sklep NV Access** w jednym dostępnym interfejsie.
+
+**Autor:** Héctor J. Benítez Corredera<br>
+**Licencja:** GNU General Public License v2<br>
+**Wersja:** 2026.05.09<br>
+**Zgodność:** NVDA 2025.1 do NVDA 2026.1<br>
+**Repozytorium:** [https://github.com/hxebolax/Tienda-para-NVDA](https://github.com/hxebolax/Tienda-para-NVDA)
+
+---
+
+## Spis treści
+
+1. [Wprowadzenie](#introduccion)
+2. [Instalacja](#instalacion)
+3. [Pierwsze kroki](#primeros-pasos)
+4. [Trzy sklepy](#las-tres-tiendas)
+5. [Interfejs sklepu](#la-interfaz-de-la-tienda)
+6. [Wskaźniki stanu](#indicadores-de-estado)
+7. [Skróty klawiszowe i funkcje specjalne](#teclas-rapidas-y-funciones-especiales)
+8. [Menu kontekstowe](#menu-contextual)
+9. [Zarządzanie zainstalowanymi dodatkami](#gestion-de-complementos-instalados)
+10. [Pakowarka dodatków](#empaquetador-de-complementos)
+11. [Wyszukiwanie aktualizacji](#buscar-actualizaciones)
+12. [Panel opcji](#panel-de-opciones)
+13. [System pamięci podręcznej](#sistema-de-cache)
+14. [Tryb offline](#modo-offline)
+15. [Kopia zapasowa i przywracanie](#backup-y-restauracion)
+16. [Tłumaczenie opisów](#traduccion-de-descripciones)
+17. [Serwery niestandardowe](#servidores-personalizados)
+18. [Uwagi i zabezpieczenia](#observaciones-y-protecciones)
+19. [Podsumowanie skrótów klawiszowych](#resumen-de-teclas-rapidas)
+20. [Rejestr zmian](#registro-de-cambios)
+
+---
+
+<a name="introduccion"></a>
+## Wprowadzenie
+
+**Sklep z dodatkami dla NVDA** jest kompletnym rozwinięciem dawnego sklepu dla NVDA.ES. Został przebudowany od podstaw, aby zapewnić nowocześniejsze, szybsze i ujednolicone korzystanie z dodatków.
+
+### Co nowego w porównaniu z poprzednią wersją?
+
+- **Ujednolicony sklep:** przeglądanie dodatków z NVDA.ES i oficjalnego sklepu NV Access w jednym oknie.
+- **Wskaźniki stanu:** każdy dodatek pokazuje bieżący stan, na przykład zainstalowany, dostępna aktualizacja, wyłączony lub niezgodny.
+- **Zarządzanie lokalne:** wyłączanie, włączanie i odinstalowywanie dodatków bez opuszczania sklepu.
+- **Wielopoziomowa pamięć podręczna:** cache serwerów, cache tłumaczeń i cache list, co przyspiesza ładowanie.
+- **Tryb offline:** przeglądanie sklepu bez połączenia z internetem przy użyciu danych zapisanych w pamięci podręcznej.
+- **Kopia zapasowa i przywracanie:** tworzenie kopii listy dodatków i przywracanie ich po zmianie komputera.
+- **Pakowarka:** tworzenie plików `.nvda-addon` z dowolnego zainstalowanego dodatku.
+- **Cicha instalacja:** instalowanie dodatków w tle, bez dodatkowych okien dialogowych.
+- **Inteligentny restart:** sklep sprawdza, czy faktycznie coś zainstalowano, zanim poprosi o ponowne uruchomienie NVDA.
+- **Sprawdzanie zależności:** przed instalacją weryfikowane jest spełnienie wymaganych zależności.
+- **Tłumaczenie z pamięcią podręczną:** opisy można tłumaczyć klawiszem F3, a wynik jest zapisywany, aby nie wykonywać tej samej operacji ponownie.
+- **Lepsze powiadomienia:** powiadomienia o aktualizacjach pokazują źródło, czyli NVDA.ES albo sklep oficjalny, oraz nazwy dodatków.
+
+---
+
+<a name="instalacion"></a>
+## Instalacja
+
+1. Pobierz plik `.nvda-addon` ze strony [wydań repozytorium](https://github.com/hxebolax/Tienda-para-NVDA/releases).
+2. Otwórz pobrany plik albo przeciągnij go na okno NVDA.
+3. Potwierdź instalację, gdy NVDA o to poprosi.
+4. Uruchom NVDA ponownie, aby aktywować dodatek.
+
+---
+
+<a name="primeros-pasos"></a>
+## Pierwsze kroki
+
+Dodatek jest dostarczany **bez przypisanych skrótów klawiszowych**. Własne skróty możesz przypisać w:
+
+**Menu NVDA -> Preferencje -> Zdarzenia wejścia -> Sklep z dodatkami NVDA**
+
+Znajdziesz tam następujące akcje:
+
+- Pokaż okno ze wszystkimi dodatkami NVDA.ES
+- Wyszukaj aktualizacje dodatków zainstalowanych z NVDA.ES
+- Pokaż okno ze wszystkimi dodatkami z oficjalnego sklepu
+- Wyszukaj aktualizacje oficjalnych dodatków
+- Pokaż ujednolicony sklep ze wszystkimi źródłami dodatków
+
+### Dostęp z menu
+
+Do wszystkich funkcji można też przejść z menu NVDA:
+
+**Menu NVDA -> Narzędzia -> Sklep z dodatkami NVDA**
+
+W tym miejscu dostępne są następujące podmenu:
+
+- **Sklep NVDA.ES:** lista dodatków i wyszukiwanie aktualizacji ze społeczności hiszpańskojęzycznej.
+- **Oficjalny sklep NVDA:** lista dodatków i wyszukiwanie aktualizacji z oficjalnego sklepu.
+- **Ujednolicony sklep (wszystkie źródła):** pokazuje wszystkie dodatki ze wszystkich źródeł na jednej liście.
+- **Pakowarka dodatków:** pozwala spakować zainstalowane dodatki jako pliki `.nvda-addon`.
+- **Dokumentacja dodatku:** otwiera tę dokumentację w domyślnej przeglądarce.
+
+---
+
+<a name="las-tres-tiendas"></a>
+## Trzy sklepy
+
+Nowa wersja integruje trzy tryby wyświetlania dodatków.
+
+### Sklep NVDA.ES
+
+Jest to sklep społeczności hiszpańskojęzycznej. Pobiera dodatki z serwera [https://nvda.es](https://nvda.es) oraz z dowolnego serwera niestandardowego, który dodasz samodzielnie.
+
+### Oficjalny sklep NVDA
+
+Zapewnia dostęp do oficjalnego sklepu dodatków NV Access ([https://addons.nvda-project.org](https://addons.nvda-project.org)). Dodatki z tego źródła są pobierane bezpośrednio z API oficjalnego sklepu i pokazywane z pełnymi informacjami o zgodności.
+
+### Ujednolicony sklep
+
+To widok łączony, który pokazuje **wszystkie dodatki ze wszystkich źródeł** na jednej liście. Dodatki są oznaczane etykietami `[ES]` (społeczność hiszpańskojęzyczna) i `[OF]` (sklep oficjalny), aby było wiadomo, skąd pochodzi dany dodatek.
+
+---
+
+<a name="la-interfaz-de-la-tienda"></a>
+## Interfejs sklepu
+
+Po otwarciu dowolnego sklepu pojawia się okno podzielone na dwa panele.
+
+### Lewy panel, czyli obszar pracy
+
+1. **Pole wyszukiwania:** po otwarciu sklepu fokus trafia właśnie tutaj. Wpisz dowolny tekst i naciśnij Enter, aby przefiltrować listę. Aby ponownie pokazać wszystkie dodatki, usuń zawartość pola i naciśnij Enter przy pustym polu.
+
+2. **Lista dodatków:** pokazuje wszystkie dostępne dodatki wraz ze wskaźnikiem stanu w nawiasach kwadratowych, na przykład `[I]` albo `[U]`. Po liście poruszasz się strzałkami w górę i w dół.
+
+3. **Przycisk akcji, Instaluj/Aktualizuj:** jest dynamiczny i automatycznie zmienia tekst zależnie od stanu zaznaczonego dodatku:
+   - jeśli dodatek nie jest zainstalowany, pokazuje **"Instaluj"**;
+   - jeśli jest dostępna aktualizacja, pokazuje **"Aktualizuj"**.
+
+### Prawy panel, czyli karta informacyjna
+
+Podczas poruszania się po liście dodatków ten panel wypełnia się pełnymi informacjami o zaznaczonym dodatku:
+
+- nazwa i podsumowanie;
+- wersja dostępna na serwerze;
+- wersja zainstalowana, jeśli dotyczy;
+- autor;
+- pełny opis;
+- zgodność z NVDA, czyli wersja minimalna i ostatnia przetestowana;
+- liczba pobrań, jeśli jest dostępna;
+- stan instalacji.
+
+---
+
+<a name="indicadores-de-estado"></a>
+## Wskaźniki stanu
+
+Podczas poruszania się po liście dodatków NVDA wypowiada litery w nawiasach kwadratowych. Oznaczają one stan danego dodatku.
+
+| Wskaźnik | Znaczenie |
+|:---------|:----------|
+| **[I]** | **Zainstalowany:** dodatek jest zainstalowany i aktywny. |
+| **[U]** | **Aktualizacja:** dostępna jest nowsza wersja. Warto zaktualizować. |
+| **[U-I]** | **Niezgodna aktualizacja:** dostępna jest nowsza wersja, ale nie jest zgodna z Twoją wersją NVDA. |
+| **[D]** | **Wyłączony:** dodatek jest zainstalowany, ale ręcznie wyłączony. |
+| **[R]** | **Oczekuje na usunięcie:** dodatek zostanie usunięty po ponownym uruchomieniu NVDA. |
+| **[I-I]** | **Zainstalowany niezgodny:** dodatek jest zainstalowany, ale zablokowany z powodu niezgodności z Twoją wersją NVDA. |
+| **[X]** | **Niezgodny:** dodatek nie jest zgodny z Twoją wersją NVDA. |
+
+W **ujednoliconym sklepie** widoczne jest również źródło dodatku.
+
+| Etykieta | Źródło |
+|:---------|:------|
+| **[ES]** | Serwery NVDA.ES, czyli społeczność hiszpańskojęzyczna |
+| **[OF]** | Oficjalny sklep NV Access |
+
+---
+
+<a name="teclas-rapidas-y-funciones-especiales"></a>
+## Skróty klawiszowe i funkcje specjalne
+
+Te klawisze działają wtedy, gdy fokus znajduje się na liście dodatków.
+
+### F1 - bieżąca pozycja
+
+Naciśnij **F1**, aby NVDA powiedział, na której pozycji listy jesteś, na przykład: "Dodatek 15 z 200".
+
+### Ctrl+F1 - wyjaśnienie wskaźnika
+
+Jeśli nie pamiętasz, co oznaczają wskaźniki `[I]` albo `[U]`, naciśnij **Ctrl+F1**. NVDA wyjaśni prostym językiem stan zaznaczonego dodatku.
+
+### F2 - odczytanie całej karty
+
+Naciśnij **F2**, aby NVDA przeczytał całą kartę techniczną i opis dodatku **bez przechodzenia tabulatorem do prawego panelu**. Działa to we wszystkich sklepach.
+
+### F3 - tłumaczenie opisu
+
+Jeśli opis jest po angielsku albo w innym języku, naciśnij **F3**, a sklep przetłumaczy go na język ustawiony w opcjach. Domyślnie jest to hiszpański, ale można wybrać też polski. Na początku i na końcu tłumaczenia odtworzony zostanie dźwięk.
+
+> **Uwaga:** aby używać F3, musisz najpierw włączyć tłumacza w opcjach dodatku. Funkcja wymaga połączenia z internetem.
+
+---
+
+<a name="menu-contextual"></a>
+## Menu kontekstowe
+
+Na liście dodatków naciśnij **klawisz aplikacji** albo **Shift+F10**, aby otworzyć menu kontekstowe z następującymi opcjami.
+
+### Filtry
+
+- **Pokaż wszystkie dodatki:** pokazuje pełną listę. Jest to opcja domyślna.
+- **Pokaż dodatki według zgodności API:** filtruje dodatki zgodne z określoną wersją NVDA.
+- **Pokaż dodatki posortowane według autora:** sortuje listę według nazwy autora.
+- **Pokaż według liczby pobrań od największej do najmniejszej:** sortuje dodatki według popularności.
+
+> **Uwaga:** filtry nie łączą się ze sobą. Każdy filtr działa osobno, a tytuł okna informuje o aktywnym filtrze. Wybrany filtr pozostaje aktywny do czasu ponownego uruchomienia NVDA.
+
+### Kopiowanie do schowka
+
+- **Kopiuj informacje:** kopiuje pełną kartę zaznaczonego dodatku.
+- **Kopiuj link do strony internetowej:** kopiuje oficjalny adres URL dodatku.
+- **Kopiuj link pobierania:** podmenu z dostępnymi gałęziami rozwoju, z którego można skopiować bezpośredni adres pobierania.
+
+---
+
+<a name="gestion-de-complementos-instalados"></a>
+## Zarządzanie zainstalowanymi dodatkami
+
+Jedną z ważniejszych funkcji jest możliwość zarządzania już zainstalowanym dodatkiem **bez opuszczania sklepu**.
+
+1. Wybierz na liście dodatek oznaczony jako `[I]`, `[D]` albo `[U]`.
+2. Naciśnij **klawisz aplikacji** albo kliknij prawym przyciskiem.
+3. W podmenu **Zarządzanie zainstalowanym** znajdziesz:
+
+- **Wyłącz / Włącz:** tymczasowo wyłącza albo włącza dodatek.
+- **Odinstaluj:** oznacza dodatek do usunięcia. Usunięcie nastąpi po ponownym uruchomieniu NVDA.
+- **Zobacz dokumentację:** otwiera dokumentację dodatku w przeglądarce. Jeśli dokumentacja istnieje w Twoim języku, zostanie otwarta ta wersja; w przeciwnym razie użyty zostanie domyślny język dodatku.
+
+---
+
+<a name="empaquetador-de-complementos"></a>
+## Pakowarka dodatków
+
+Pakowarka pozwala tworzyć pliki `.nvda-addon` z dodatków, które są już zainstalowane. Przydaje się to do:
+
+- udostępnienia dodatku innej osobie bez szukania go w sklepie;
+- utworzenia kopii zapasowej konkretnego dodatku;
+- zachowania wybranej wersji dodatku przed aktualizacją.
+
+**Aby spakować dodatek:**
+
+1. Przejdź do **Menu NVDA -> Narzędzia -> Sklep z dodatkami NVDA -> Pakowarka dodatków**.
+2. Wybierz z listy dodatek, który chcesz spakować.
+3. Wskaż katalog, w którym ma zostać zapisany plik.
+4. Plik `.nvda-addon` zostanie utworzony automatycznie w formacie `nazwa_wersja_Gen.nvda-addon`.
+
+---
+
+<a name="buscar-actualizaciones"></a>
+## Wyszukiwanie aktualizacji
+
+Dodatek oferuje dwa sposoby wyszukiwania aktualizacji.
+
+### Wyszukiwanie ręczne
+
+W menu narzędzi wybierz **Szukaj aktualizacji** w jednym ze sklepów, NVDA.ES albo oficjalnym. Zostanie wyświetlone okno z dodatkami, dla których są dostępne aktualizacje.
+
+W tym oknie możesz:
+
+- **wybierać dodatki pojedynczo:** użyj spacji, aby zaznaczać lub odznaczać pozycje;
+- **Alt+S:** zaznaczyć wszystkie dodatki do aktualizacji;
+- **Alt+D:** odznaczyć wszystkie dodatki;
+- **Alt+A:** rozpocząć aktualizowanie zaznaczonych dodatków;
+- **Alt+C / Escape / Alt+F4:** zamknąć okno.
+
+### Sprawdzanie automatyczne
+
+Po włączeniu automatycznego sprawdzania w opcjach:
+
+- sklep będzie szukał aktualizacji w tle zgodnie z ustawionym interwałem;
+- pojawi się powiadomienie systemowe z liczbą aktualizacji i ich źródłem;
+- wyszukiwanie zatrzyma się automatycznie po 10 sprawdzeniach bez wyniku albo po 5 sprawdzeniach po znalezieniu aktualizacji, aby nie przeciążać serwera.
+
+Powiadomienia są bardziej szczegółowe, na przykład:
+
+```text
+Znaleziono 3 aktualizacje.
+- NVDA.ES (2): Dodatek A, Dodatek B
+- Oficjalny sklep (1): Dodatek C
+
+Uruchom wyszukiwanie aktualizacji dodatków.
+```
+
+---
+
+<a name="panel-de-opciones"></a>
+## Panel opcji
+
+Konfigurację dodatku otworzysz z:
+
+**Menu NVDA -> Preferencje -> Opcje -> Sklep z dodatkami NVDA**
+
+### A. Sklep NVDA.ES
+
+- **Wybierz serwer dodatków:** wybiera domyślny serwer spośród skonfigurowanych serwerów.
+- **Zarządzaj serwerami dodatków:** otwiera menedżer, w którym możesz dodawać, edytować i usuwać serwery niestandardowe.
+
+### B. Oficjalny sklep NVDA
+
+- **Włącz oficjalny sklep NVDA:** włącza albo wyłącza integrację z oficjalnym sklepem NV Access.
+- **Zezwalaj na niezgodne dodatki z oficjalnego sklepu:** pozwala próbować instalować dodatki oznaczone jako niezgodne. **Używasz tej opcji na własną odpowiedzialność.**
+
+### C. Aktualizacje
+
+- **Włącz automatyczne sprawdzanie aktualizacji:** uruchamia wyszukiwanie w tle.
+- **Interwał sprawdzania aktualizacji:** pozwala wybrać odstęp między sprawdzeniami:
+  - 15 minut, 30 minut, 45 minut, 1 godzina, 12 godzin, 1 dzień, 1 tydzień.
+- **Uwzględniaj aktualizacje z oficjalnego sklepu:** dodaje aktualizacje z oficjalnego sklepu do automatycznego sprawdzania.
+
+### D. Tłumaczenie
+
+- **Włącz tłumacza opisów:** włącza użycie klawisza F3 do tłumaczenia opisów.
+- **Język tłumaczenia opisów:** wybierz jeden z 12 języków: niemiecki, arabski, chorwacki, hiszpański, francuski, angielski, włoski, polski, portugalski, rosyjski, turecki i ukraiński.
+
+### E. Opcje ogólne
+
+- **Sortuj dodatki alfabetycznie:** sortuje listę od A do Z.
+- **Instaluj dodatki po pobraniu:** po zakończeniu pobierania automatycznie otwiera kreatora instalacji.
+- **Instaluj po cichu:** dodatki są instalowane w tle, bez dodatkowych okien dialogowych. Na końcu pojawia się tylko prośba o ponowne uruchomienie.
+- **Włącz pamięć podręczną serwerów:** zapisuje listy dodatków na dysku, aby szybciej je ładować.
+- **Odświeżaj pamięć podręczną co...:** ustawia interwał odnawiania cache.
+- **Używaj pamięci podręcznej dla tłumaczeń:** tłumaczenia wykonane klawiszem F3 są zapisywane, aby nie pytać ponownie Google.
+- **Włącz tryb offline:** pozwala przeglądać sklep bez internetu, używając list zapisanych w cache.
+
+### F. Kopia zapasowa i przywracanie
+
+- **Utwórz kopię zapasową dodatków:** generuje plik JSON z listą wszystkich zainstalowanych dodatków.
+- **Przywróć z kopii zapasowej:** wczytuje plik kopii zapasowej i pozwala ponownie zainstalować wymienione w nim dodatki.
+
+### G. Zainstalowane dodatki dostępne na serwerze
+
+Na dole opcji znajduje się lista Twoich dodatków, które są też dostępne na serwerze. Z tego miejsca możesz:
+
+1. Wybrać dodatek i nacisnąć **spację**.
+2. W menu podręcznym wybrać **kanał aktualizacji** (stabilny, beta, rozwojowy itd.) albo **Odrzuć aktualizacje**, aby sklep przestał informować o tym dodatku.
+
+> **Ważne:** zmiany są zapisywane dopiero po naciśnięciu OK albo Zastosuj w oknie opcji.
+
+---
+
+<a name="sistema-de-cache"></a>
+## System pamięci podręcznej
+
+Sklep używa wielopoziomowego systemu pamięci podręcznej, aby przyspieszyć działanie.
+
+### Cache serwerów
+
+Listy dodatków są zapisywane na dysku. Jeśli cache nie wygasł, po otwarciu sklepu lista jest ładowana z dysku zamiast z serwera.
+
+- Opcja znajduje się w ustawieniu **Włącz pamięć podręczną serwerów**.
+- Interwał odświeżania można skonfigurować.
+
+### Cache tłumaczeń
+
+Tłumaczenia wykonane klawiszem F3 są zapisywane w trwałym pliku JSON. Przy kolejnym żądaniu tego samego tłumaczenia wynik zostanie odczytany natychmiast z cache.
+
+- Opcja znajduje się w ustawieniu **Używaj pamięci podręcznej dla tłumaczeń**.
+
+### Cache w pamięci RAM
+
+Oprócz cache na dysku sklep przechowuje najczęstsze zapytania w pamięci RAM, co ogranicza dostęp do dysku podczas bieżącej sesji.
+
+---
+
+<a name="modo-offline"></a>
+## Tryb offline
+
+Tryb offline pozwala przeglądać sklep **bez połączenia z internetem**, używając wcześniej zapisanych danych.
+
+Aby go używać:
+
+1. Włącz opcje **Włącz pamięć podręczną serwerów** i **Włącz tryb offline**.
+2. Otwórz sklep przynajmniej raz z działającym internetem, aby utworzyć cache.
+3. Następnym razem, gdy otworzysz sklep bez internetu, dane zostaną wczytane z cache.
+
+> **Uwaga:** w trybie offline nie można pobierać ani instalować dodatków, ale można czytać informacje o dodatkach, które wcześniej zostały zapisane w cache.
+
+---
+
+<a name="backup-y-restauracion"></a>
+## Kopia zapasowa i przywracanie
+
+### Tworzenie kopii zapasowej
+
+1. Przejdź do **Opcje -> Sklep z dodatkami NVDA -> Utwórz kopię zapasową dodatków**.
+2. Wybierz nazwę i miejsce zapisu pliku `.json`.
+3. Zostanie utworzony plik z listą wszystkich zainstalowanych dodatków, obejmujący nazwę, wersję i podsumowanie.
+
+### Automatyczna kopia przy zamykaniu
+
+Sklep może automatycznie tworzyć kopię zapasową przy zamykaniu NVDA, jeśli odpowiednia opcja jest włączona.
+
+### Przywracanie z kopii zapasowej
+
+1. Przejdź do **Opcje -> Sklep z dodatkami NVDA -> Przywróć z kopii zapasowej**.
+2. Wybierz plik `.json` kopii zapasowej.
+3. Sklep pokaże kreatora, który wyszuka najnowsze wersje każdego dodatku na serwerach i pozwoli zainstalować je zbiorczo.
+
+> **Przydatne do:** przeniesienia dodatków na nowy komputer albo odtworzenia konfiguracji po ponownej instalacji NVDA.
+
+---
+
+<a name="traduccion-de-descripciones"></a>
+## Tłumaczenie opisów
+
+Sklep ma wbudowanego tłumacza opartego o Google Translate.
+
+1. **Włącz tłumacza** w opcjach dodatku.
+2. **Wybierz język docelowy**, domyślnie jest to hiszpański.
+3. **Naciśnij F3** na dowolnym dodatku na liście, aby przetłumaczyć jego opis.
+
+Funkcje:
+
+- dźwięk rozpoczęcia i zakończenia tłumaczenia;
+- zapisywanie tłumaczeń w cache, aby nie powtarzać tych samych zapytań;
+- tłumaczenie znika po przejściu do innego dodatku, więc w razie potrzeby naciśnij F3 ponownie;
+- wymagane jest połączenie z internetem.
+
+---
+
+<a name="servidores-personalizados"></a>
+## Serwery niestandardowe
+
+Możesz dodać zewnętrzne repozytoria dodatków, jeśli używają formatu zgodnego z NVDA.ES.
+
+### Dodawanie serwera
+
+1. Przejdź do **Opcje -> Sklep z dodatkami NVDA -> Zarządzaj serwerami dodatków**.
+2. Naciśnij **Dodaj**.
+3. Wpisz opisową nazwę i adres URL serwera.
+4. Zatwierdź, a serwer pojawi się w wyborze serwerów.
+
+### Przykład: serwer społeczności rosyjskiej
+
+- **Nazwa:** Społeczność rosyjska
+- **URL:** `https://nvda-addons.ru/get.php?addonslist`
+
+### Szybka zmiana serwera
+
+W głównym oknie sklepu NVDA.ES naciśnij **Alt+C** albo przycisk **Zmień serwer**, aby rozwinąć menu z wszystkimi skonfigurowanymi serwerami. Zmiana działa natychmiast i tymczasowo; jako domyślna zostanie zapisana dopiero po zmianie w opcjach.
+
+> **Uwaga:** domyślnego serwera społeczności hiszpańskojęzycznej nie można edytować ani usunąć.
+
+---
+
+<a name="observaciones-y-protecciones"></a>
+## Uwagi i zabezpieczenia
+
+Dodatek zawiera kilka zabezpieczeń, które mają zapewnić stabilne działanie:
+
+1. **Dodatki oczekujące na odinstalowanie:** są automatycznie pomijane podczas sprawdzania aktualizacji.
+2. **Walidacja zgodności API:** nawet jeśli wersja na serwerze jest nowsza, aktualizacja nie zostanie zaproponowana, jeśli nie jest zgodna z Twoją wersją NVDA.
+3. **Powiadomienia o błędach instalacji:** jeśli któregoś dodatku nie uda się zaktualizować, pojawi się informacja z jego nazwą.
+4. **Blokada po aktualizacji:** sklep nie pozwala szukać kolejnych aktualizacji, jeśli wykonano aktualizację i NVDA nie został jeszcze ponownie uruchomiony.
+5. **Powiadomienie po restarcie:** jeśli automatyczne sprawdzanie wykryje, że po aktualizacji nie uruchomiono ponownie NVDA, pojawi się przypomnienie.
+6. **Ochrona przy braku internetu:** jeśli biblioteki nie mogą zostać wczytane z powodu braku połączenia, informacja trafi do logu NVDA, a przy próbie wejścia do sklepu usłyszysz komunikat.
+7. **Inteligentny restart:** sklep wykrywa, czy dodatek faktycznie został zainstalowany. Jeśli anulujesz instalator, nie będzie niepotrzebnej prośby o restart.
+8. **Sprawdzanie zależności:** przed instalacją weryfikowane jest spełnienie wymaganych zależności.
+
+---
+
+<a name="resumen-de-teclas-rapidas"></a>
+## Podsumowanie skrótów klawiszowych
+
+### Główne okno sklepu
+
+| Akcja | Klawisz |
+|:------|:--------|
+| Przejście do pola wyszukiwania | `Alt+B` |
+| Przejście do listy dodatków | `Alt+L` |
+| Instalacja / aktualizacja | `Alt+I` |
+| Przejście do informacji o dodatku | `Alt+I` w prawym panelu |
+| Przejście do strony internetowej dodatku | `Alt+P` |
+| Zmiana serwera, tylko NVDA.ES | `Alt+C` |
+| Zamknięcie sklepu | `Alt+S` / `Escape` / `Alt+F4` |
+
+### Na liście dodatków
+
+| Akcja | Klawisz |
+|:------|:--------|
+| Odczyt bieżącej pozycji na liście | `F1` |
+| Wyjaśnienie wskaźnika stanu | `Ctrl+F1` |
+| Odczyt pełnej karty dodatku | `F2` |
+| Tłumaczenie opisu | `F3` |
+| Menu kontekstowe, filtry, kopiowanie i zarządzanie | `Klawisz aplikacji` / `Shift+F10` |
+
+### Okno aktualizacji
+
+| Akcja | Klawisz |
+|:------|:--------|
+| Zaznaczenie wszystkich dodatków | `Alt+S` |
+| Odznaczenie wszystkich | `Alt+D` |
+| Rozpoczęcie aktualizacji | `Alt+A` |
+| Zamknięcie okna | `Alt+C` / `Escape` / `Alt+F4` |
+
+---
+
+<a name="registro-de-cambios"></a>
+## Rejestr zmian
+
+### Wersja 2026.05.11
+
+* Dodano cichy aktualizator języków dodatku (w fazie beta).
+* Dodano język rosyjski (Valentín N. Kupriyanov).
+
+### Wersja 2026.05.10
+
+* Dodano język turecki (Umut Korkmaz).
+
+### Wersja 2026.05.09
+
+* Pierwsza wersja ujednoliconego sklepu dodatków dla NVDA.
+* Pełna integracja sklepu NVDA.ES i oficjalnego sklepu NV Access.
+* Nowy system wskaźników stanu: [I], [U], [D], [R], [I-I], [U-I], [X].
+* Lokalne zarządzanie dodatkami: wyłączanie, włączanie i odinstalowywanie bez opuszczania sklepu.
+* Wielopoziomowy system pamięci podręcznej: cache serwerów, cache tłumaczeń i cache list.
+* Tryb offline: przeglądanie sklepu bez internetu przy użyciu danych zapisanych w cache.
+* Kopia zapasowa i przywracanie zainstalowanych dodatków.
+* Pakowarka dodatków: tworzenie plików `.nvda-addon` z zainstalowanych dodatków.
+* Inteligentne sprawdzanie zależności i zgodności API.
+* Cicha instalacja z inteligentnym restartem.
+* Tłumaczenie opisów z trwałą pamięcią podręczną przez Google Translate.
+* Obsługa niestandardowych serwerów dodatków.
+* Interfejs ze skrótami F1, Ctrl+F1, F2 i F3 do szybkiego dostępu do funkcji.
+* Szczegółowe powiadomienia wskazujące źródło aktualizacji, czyli ES albo oficjalne.
+
+### Poprzednie wersje, sklep dla NVDA.ES
+
+To repozytorium zawierało wcześniej klasyczną wersję **sklepu dla NVDA.ES** (wersje 0.1 do 0.10). Od wersji 2026.05.09 repozytorium zostało zastąpione nowym **ujednoliconym sklepem dodatków dla NVDA**, czyli kompletnym przepisaniem dodatku.
+
+Jeśli chcesz sprawdzić kod źródłowy albo dokumentację starej wersji, możesz przejrzeć historię commitów w repozytorium GitHub:
+
+1. Przejdź do [https://github.com/hxebolax/Tienda-para-NVDA](https://github.com/hxebolax/Tienda-para-NVDA).
+2. Kliknij link **commits** albo licznik commitów widoczny u góry repozytorium.
+3. Znajdź dowolny commit sprzed **9 maja 2026**, aby uzyskać dostęp do kodu i wydań klasycznego sklepu.
+4. Po wejściu w wybrany commit możesz kliknąć **Browse files**, aby zobaczyć pełny stan repozytorium z tego momentu.
+
+Alternatywnie starsze wydania z plikami `.nvda-addon` powinny pozostać dostępne w sekcji [Releases](https://github.com/hxebolax/Tienda-para-NVDA/releases), o ile nie zostaną ręcznie usunięte.
+
+---
+
+Miłego korzystania ze sklepu z dodatkami dla NVDA.
+
+**Z pozdrowieniami:** Héctor J. Benítez Corredera.

--- a/addon/locale/pl/LC_MESSAGES/nvda.po
+++ b/addon/locale/pl/LC_MESSAGES/nvda.po
@@ -1,0 +1,1513 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: TiendaNVDA\n"
+"Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
+"POT-Creation-Date: 2026-05-09 11:52+0000\n"
+"PO-Revision-Date: 2026-05-15 00:00+0200\n"
+"Last-Translator: Kazek + Codex\n"
+"Language-Team: Polish\n"
+"Language: pl_PL\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Codex\n"
+"X-Poedit-Basepath: ../../../globalPlugins\n"
+"X-Poedit-KeywordsList: _;gettext;gettext_noop\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-SearchPath-0: .\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:23
+msgid "Gestor de servidores de complementos"
+msgstr "Menedżer serwerów dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:27
+msgid "&Lista de servidores:"
+msgstr "&Lista serwerów:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:35
+msgid "&Añadir"
+msgstr "&Dodaj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:36
+msgid "&Editar"
+msgstr "&Edytuj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:37
+msgid "&Borrar"
+msgstr "&Usuń"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:42
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:172
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:52
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:117
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:190
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:361
+msgid "&Cerrar"
+msgstr "Za&mknij"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:65
+msgid "El servidor de la comunidad hispanohablante no puede ser editado."
+msgstr "Nie można edytować serwera społeczności hiszpańskojęzycznej."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:78
+msgid "El servidor de la comunidad hispanohablante no puede ser borrado."
+msgstr "Nie można usunąć serwera społeczności hiszpańskojęzycznej."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:80
+msgid "¿Está seguro que desea borrar el servidor: {}?"
+msgstr "Czy na pewno chcesz usunąć serwer: {}?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:81
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:71
+msgid "Confirmar"
+msgstr "Potwierdzenie"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:109
+msgid "Añadir servidor"
+msgstr "Dodaj serwer"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:109
+msgid "Editar servidor"
+msgstr "Edytuj serwer"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:114
+msgid "&Nombre del servidor:"
+msgstr "&Nazwa serwera:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:117
+msgid "&URL del servidor:"
+msgstr "Adres &URL serwera:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:121
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:171
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:51
+msgid "&Aceptar"
+msgstr "&OK"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:122
+msgid "&Cancelar"
+msgstr "&Anuluj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:137
+msgid "El nombre del servidor no puede estar vacío."
+msgstr "Nazwa serwera nie może być pusta."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:141
+msgid "La URL del servidor no puede estar vacía."
+msgstr "Adres URL serwera nie może być pusty."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:146
+msgid "Ya existe un servidor con ese nombre."
+msgstr "Serwer o tej nazwie już istnieje."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:149
+msgid "La URL introducida no es válida."
+msgstr "Wprowadzony adres URL jest nieprawidłowy."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:162
+msgid "Servidor sin complementos"
+msgstr "Serwer bez dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:167
+msgid "Seleccione un servidor"
+msgstr "Wybierz serwer"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:183
+msgid "Debe seleccionar un servidor."
+msgstr "Musisz wybrać serwer."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_servidores.py:183
+#: addon/globalPlugins/TiendaNVDA/hilos.py:80
+#: addon/globalPlugins/TiendaNVDA/hilos.py:99
+#: addon/globalPlugins/TiendaNVDA/__init__.py:50
+msgid "Información"
+msgstr "Informacja"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:36
+msgid "Tienda Unificada de Complementos"
+msgstr "Ujednolicony sklep dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:53
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:57
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:50
+msgid "&Buscar:"
+msgstr "&Szukaj:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:58
+msgid "&Fuente:"
+msgstr "Ź&ródło:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:59
+msgid "Todas las fuentes"
+msgstr "Wszystkie źródła"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:59
+msgid "NVDA.ES"
+msgstr "NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:59
+msgid "Tienda Oficial"
+msgstr "Oficjalny sklep"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:64
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:65
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:61
+msgid "&Lista complementos:"
+msgstr "&Lista dodatków:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:70
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:70
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:67
+msgid "&Acción"
+msgstr "&Akcja"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:74
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:74
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:71
+msgid "&Información:"
+msgstr "&Informacje:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:80
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:188
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:80
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:231
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:77
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:156
+msgid "&Instalar"
+msgstr "&Instaluj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:81
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:81
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:78
+msgid "&Descargar"
+msgstr "&Pobierz"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:82
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:84
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:80
+msgid "&Salir"
+msgstr "Wyj&dź"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:167
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:187
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:200
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:232
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:138
+msgid "No se encontraron resultados"
+msgstr "Nie znaleziono wyników"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:188
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:229
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:156
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:116
+msgid "&Actualizar"
+msgstr "&Aktualizuj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:196
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:273
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:340
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:164
+msgid "Activo"
+msgstr "Aktywny"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:198
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:275
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:342
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:166
+msgid "Deshabilitado (incompatible)"
+msgstr "Wyłączony (niezgodny)"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:198
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:275
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:166
+msgid "Habilitado (compatibilidad anulada)"
+msgstr "Włączony (zgodność pominięta)"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:200
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:277
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:344
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:168
+msgid "Deshabilitado"
+msgstr "Wyłączony"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:201
+msgid ""
+"\n"
+"ESTADO LOCAL: {} (v{})\n"
+msgstr ""
+"\n"
+"STAN LOKALNY: {} (v{})\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:204
+msgid "RESUMEN DEL COMPLEMENTO [NVDA.ES]\n"
+msgstr ""
+"PODSUMOWANIE DODATKU [NVDA.ES]\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:206
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:220
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:256
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:264
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:292
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:351
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:175
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:210
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:441
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:451
+msgid "Nombre: {}\n"
+msgstr ""
+"Nazwa: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:207
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:221
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:257
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:265
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:352
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:176
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:211
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:442
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:452
+msgid "ID: {}\n"
+msgstr ""
+"ID: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:208
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:294
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:353
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:444
+msgid "Autor: {}\n"
+msgstr ""
+"Autor: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:209
+msgid "Web: {}\n"
+msgstr ""
+"Strona: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:209
+msgid "No disponible"
+msgstr "Niedostępne"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:211
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:226
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:298
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:182
+msgid "DESCRIPCIÓN:"
+msgstr "OPIS:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:213
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:228
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:184
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:447
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:457
+msgid "Sin descripción."
+msgstr "Brak opisu."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:214
+msgid "ENLACES:"
+msgstr "LINKI:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:216
+msgid "Canal {}: v{} (Min NVDA: {})\n"
+msgstr ""
+"Kanał {}: v{} (min. NVDA: {})\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:218
+msgid "RESUMEN DEL COMPLEMENTO [OFICIAL]\n"
+msgstr ""
+"PODSUMOWANIE DODATKU [OFICJALNY]\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:222
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:177
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:212
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:454
+msgid "Editor: {}\n"
+msgstr ""
+"Wydawca: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:223
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:347
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:171
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:178
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:213
+msgid "Versión: {}\n"
+msgstr ""
+"Wersja: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:224
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:179
+msgid "Canal: {}\n"
+msgstr ""
+"Kanał: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:234
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:313
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:190
+msgid "Active la traducción en opciones de la tienda."
+msgstr "Włącz tłumaczenie w opcjach sklepu."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:252
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:334
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:207
+msgid "No se pudo traducir"
+msgstr "Nie udało się przetłumaczyć"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:254
+msgid "RESUMEN (TRADUCIDO - NVDA.ES)\n"
+msgstr ""
+"PODSUMOWANIE (PRZETŁUMACZONE - NVDA.ES)\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:258
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:266
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:355
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:214
+msgid "DESCRIPCIÓN TRADUCIDA:"
+msgstr "PRZETŁUMACZONY OPIS:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:262
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:208
+msgid "RESUMEN (TRADUCIDO - OFICIAL)\n"
+msgstr ""
+"PODSUMOWANIE (PRZETŁUMACZONE - OFICJALNY)\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:283
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:238
+msgid "Copiar ficha"
+msgstr "Kopiuj kartę"
+
+#. Copiar enlace interno NVDA.ES
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:288
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:395
+msgid "Copiar enlace interno NVDA.ES"
+msgstr "Kopiuj wewnętrzny link NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:293
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:417
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:401
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:486
+#: addon/globalPlugins/TiendaNVDA/__init__.py:621
+msgid "Canal {}"
+msgstr "Kanał {}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:295
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:297
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:300
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:403
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:405
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:239
+msgid "Copiar enlace de descarga"
+msgstr "Kopiuj link pobierania"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:308
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:416
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:247
+msgid "&Gestión instalado"
+msgstr "&Zarządzanie zainstalowanym"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:323
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:247
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:262
+msgid "Complemento {} de {}"
+msgstr "Dodatek {} z {}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:344
+#, python-brace-format
+msgid ""
+"Indicador: {indicator}\n"
+"Fuente: {source}\n"
+"{explanation}"
+msgstr ""
+"Wskaźnik: {indicator}\n"
+"Źródło: {source}\n"
+"{explanation}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:344
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:218
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:278
+msgid "Sin indicador"
+msgstr "Bez wskaźnika"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:370
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:443
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:286
+msgid "Este complemento no es compatible con su versión de NVDA."
+msgstr "Ten dodatek nie jest zgodny z Twoją wersją NVDA."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:370
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:443
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:286
+msgid "Incompatible"
+msgstr "Niezgodny"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:372
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:446
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:288
+msgid ""
+"Este complemento no es compatible. ¿Desea intentar instalarlo de todos modos?"
+msgstr "Ten dodatek nie jest zgodny. Czy mimo to chcesz spróbować go zainstalować?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:372
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:446
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:288
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:500
+msgid "Advertencia"
+msgstr "Ostrzeżenie"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:377
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:454
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:292
+#, python-format
+msgid "Preparando instalación de %s..."
+msgstr "Przygotowywanie instalacji %s..."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:385
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:458
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:297
+#, python-format
+msgid "Instalación de %s completada."
+msgstr "Instalacja %s zakończona."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:386
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:298
+msgid "¿Desea reiniciar NVDA ahora?"
+msgstr "Czy chcesz teraz ponownie uruchomić NVDA?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:386
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:459
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:298
+msgid "Reiniciar"
+msgstr "Uruchom ponownie"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:390
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:436
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:302
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:335
+msgid "Error: El archivo descargado está corrupto"
+msgstr "Błąd: pobrany plik jest uszkodzony"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:406
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:492
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:318
+msgid "Ya hay una descarga en progreso"
+msgstr "Pobieranie jest już w toku"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:422
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:453
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:506
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:321
+msgid "Complemento de NVDA (*.nvda-addon)|*.nvda-addon"
+msgstr "Dodatek NVDA (*.nvda-addon)|*.nvda-addon"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:423
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:454
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:507
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:322
+msgid "Guardar en..."
+msgstr "Zapisz w..."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:429
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_unificada.py:460
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:519
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:328
+#, python-format
+msgid "Descargando %s..."
+msgstr "Pobieranie %s..."
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:63
+msgid ""
+"No se pudo conectar al servidor y no hay datos en caché. ¿Desea intentar "
+"cambiar de servidor?"
+msgstr "Nie udało się połączyć z serwerem i nie ma danych w pamięci podręcznej. Czy chcesz spróbować zmienić serwer?"
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:64
+#: addon/globalPlugins/TiendaNVDA/hilos.py:90
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:143
+msgid "Error"
+msgstr "Błąd"
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:69
+msgid ""
+"Trabajando en modo OFFLINE. Los datos mostrados pueden estar "
+"desactualizados. Algunas descargas podrían no funcionar."
+msgstr "Praca w trybie OFFLINE. Wyświetlane dane mogą być nieaktualne. Niektóre pobrania mogą nie działać."
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:80
+msgid "No hay actualizaciones disponibles."
+msgstr "Brak dostępnych aktualizacji."
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:90
+msgid "No se pudieron obtener complementos de la tienda oficial."
+msgstr "Nie udało się pobrać dodatków z oficjalnego sklepu."
+
+#: addon/globalPlugins/TiendaNVDA/hilos.py:99
+msgid "No hay actualizaciones oficiales disponibles."
+msgstr "Brak dostępnych oficjalnych aktualizacji."
+
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:41
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:56
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:230
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:208
+msgid "Todos"
+msgstr "Wszystkie"
+
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:41
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:79
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:56
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:230
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:208
+msgid "Estable"
+msgstr "Stabilny"
+
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:42
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:79
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:56
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:230
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:208
+msgid "Beta"
+msgstr "Beta"
+
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:42
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:80
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:56
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:230
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:209
+msgid "Desarrollo"
+msgstr "Rozwojowy"
+
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:43
+#: addon/globalPlugins/TiendaNVDA/tienda_oficial.py:80
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:209
+msgid "Externo"
+msgstr "Zewnętrzny"
+
+#: addon/globalPlugins/TiendaNVDA/empaquetador.py:46
+msgid "Complemento empaquetado correctamente en: {}"
+msgstr "Dodatek został poprawnie spakowany w: {}"
+
+#: addon/globalPlugins/TiendaNVDA/empaquetador.py:49
+msgid "Error al empaquetar el complemento: {}"
+msgstr "Błąd podczas pakowania dodatku: {}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:61
+msgid "B&uscar"
+msgstr "Szu&kaj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:82
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:79
+msgid "&Página WEB"
+msgstr "Strona &WWW"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:83
+msgid "&Cambiar servidor"
+msgstr "&Zmień serwer"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:140
+msgid " - Todos los complementos"
+msgstr " - Wszystkie dodatki"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:141
+msgid " - Complementos API 2026"
+msgstr " - Dodatki API 2026"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:142
+msgid " - Complementos API 2025"
+msgstr " - Dodatki API 2025"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:143
+msgid " - Complementos API 2024"
+msgstr " - Dodatki API 2024"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:144
+msgid " - Complementos API 2023"
+msgstr " - Dodatki API 2023"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:145
+msgid " - Por autor"
+msgstr " - Według autora"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:146
+msgid " - Por descargas"
+msgstr " - Według liczby pobrań"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:217
+#, python-brace-format
+msgid ""
+"Indicador: {indicator}\n"
+"Fuente: [ES] Tienda NVDA.ES\n"
+"{explanation}"
+msgstr ""
+"Wskaźnik: {indicator}\n"
+"Źródło: [ES] Sklep NVDA.ES\n"
+"{explanation}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:279
+msgid "Marcado para eliminar"
+msgstr "Oznaczony do usunięcia"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:281
+msgid "Pendiente de instalar"
+msgstr "Oczekuje na instalację"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:282
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:345
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:169
+msgid ""
+"\n"
+"--- INFORMACIÓN DE INSTALACIÓN LOCAL ---\n"
+msgstr ""
+"\n"
+"--- INFORMACJE O LOKALNEJ INSTALACJI ---\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:283
+msgid "Estado actual: {}\n"
+msgstr ""
+"Bieżący stan: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:284
+msgid "Versión instalada: {}\n"
+msgstr ""
+"Zainstalowana wersja: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:286
+msgid "AVISO: Cambios pendientes. Reinicie NVDA.\n"
+msgstr ""
+"UWAGA: oczekujące zmiany. Uruchom ponownie NVDA.\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:288
+msgid "ADVERTENCIA: Complemento incompatible con este NVDA.\n"
+msgstr ""
+"OSTRZEŻENIE: dodatek niezgodny z tą wersją NVDA.\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:290
+msgid "RESUMEN DEL COMPLEMENTO\n"
+msgstr ""
+"PODSUMOWANIE DODATKU\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:293
+msgid "ID (Nombre interno): {}\n"
+msgstr ""
+"ID (nazwa wewnętrzna): {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:295
+msgid "Página web: {}\n"
+msgstr ""
+"Strona internetowa: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:296
+msgid "Desarrollo: {}\n"
+msgstr ""
+"Rozwój: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:296
+msgid "Con soporte"
+msgstr "Wspierany"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:296
+msgid "Sin soporte"
+msgstr "Niewspierany"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:300
+msgid "Sin descripción disponible."
+msgstr "Brak dostępnego opisu."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:301
+msgid "CANALES DE DESCARGA:"
+msgstr "KANAŁY POBIERANIA:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:305
+msgid ""
+"Canal: {}\n"
+"Versión: {}\n"
+"Mínimo NVDA: {}\n"
+"Última prueba: {}\n"
+"Descargas: {}\n"
+msgstr ""
+"Kanał: {}\n"
+"Wersja: {}\n"
+"Minimum NVDA: {}\n"
+"Ostatnio testowano: {}\n"
+"Pobrania: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:346
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:170
+msgid "Estado: {}\n"
+msgstr ""
+"Stan: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:349
+msgid "RESUMEN (TRADUCIDO)\n"
+msgstr ""
+"PODSUMOWANIE (PRZETŁUMACZONE)\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:372
+msgid "Mostrar todos"
+msgstr "Pokaż wszystkie"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:373
+msgid "API 2026"
+msgstr "API 2026"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:374
+msgid "API 2025"
+msgstr "API 2025"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:375
+msgid "API 2024"
+msgstr "API 2024"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:376
+msgid "API 2023"
+msgstr "API 2023"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:377
+msgid "Por autor"
+msgstr "Według autora"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:378
+msgid "Por descargas"
+msgstr "Według liczby pobrań"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:379
+msgid "&Filtros"
+msgstr "&Filtry"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:392
+msgid "Copiar información"
+msgstr "Kopiuj informacje"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:393
+msgid "Copiar URL página"
+msgstr "Kopiuj adres URL strony"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:408
+msgid "&Copiar"
+msgstr "&Kopiuj"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_es.py:459
+msgid "Instalación completada. ¿Desea reiniciar NVDA ahora?"
+msgstr "Instalacja zakończona. Czy chcesz teraz ponownie uruchomić NVDA?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:34
+#: addon/globalPlugins/TiendaNVDA/__init__.py:137
+#: addon/globalPlugins/TiendaNVDA/__init__.py:293
+msgid "Tienda Oficial NVDA"
+msgstr "Oficjalny sklep NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:55
+msgid "&Canal:"
+msgstr "&Kanał:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:173
+msgid "RESUMEN DEL COMPLEMENTO (OFICIAL)\n"
+msgstr ""
+"PODSUMOWANIE DODATKU (OFICJALNY)\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:180
+msgid "Compatible: {}\n"
+msgstr ""
+"Zgodny: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:180
+msgid "Sí"
+msgstr "Tak"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:180
+msgid "No"
+msgstr "Nie"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:233
+msgid "&Canales"
+msgstr "&Kanały"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_tienda_oficial.py:278
+#, python-brace-format
+msgid ""
+"Indicador: {indicator}\n"
+"Fuente: [OF] Tienda Oficial NVDA\n"
+"{explanation}"
+msgstr ""
+"Wskaźnik: {indicator}\n"
+"Źródło: [OF] Oficjalny sklep NVDA\n"
+"{explanation}"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:79
+msgid "Servidor comunidad hispanohablante"
+msgstr "Serwer społeczności hiszpańskojęzycznej"
+
+#. Título de la aplicación
+#. Translators: title for the addon store settings category
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:148
+#: addon/globalPlugins/TiendaNVDA/__init__.py:153
+#: addon/globalPlugins/TiendaNVDA/__init__.py:201
+#: addon/globalPlugins/TiendaNVDA/__init__.py:205
+#: addon/globalPlugins/TiendaNVDA/__init__.py:209
+#: addon/globalPlugins/TiendaNVDA/__init__.py:213
+#: addon/globalPlugins/TiendaNVDA/__init__.py:217
+#: addon/globalPlugins/TiendaNVDA/__init__.py:260
+msgid "Tienda de Complementos NVDA"
+msgstr "Sklep z dodatkami NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:168
+msgid "15 minutos"
+msgstr "15 minut"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:169
+msgid "30 minutos"
+msgstr "30 minut"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:170
+msgid "45 minutos"
+msgstr "45 minut"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:171
+msgid "1 hora"
+msgstr "1 godzina"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:172
+msgid "12 horas"
+msgstr "12 godzin"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:173
+msgid "1 día"
+msgstr "1 dzień"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:174
+msgid "1 semana"
+msgstr "1 tydzień"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:179
+msgid "Alemán"
+msgstr "niemiecki"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:180
+msgid "Árabe"
+msgstr "arabski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:181
+msgid "Croata"
+msgstr "chorwacki"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:182
+msgid "Español"
+msgstr "hiszpański"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:183
+msgid "Francés"
+msgstr "francuski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:184
+msgid "Inglés"
+msgstr "angielski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:185
+msgid "Italiano"
+msgstr "włoski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:186
+msgid "Polaco"
+msgstr "polski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:187
+msgid "Portugués"
+msgstr "portugalski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:188
+msgid "Ruso"
+msgstr "rosyjski"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:189
+msgid "Turco"
+msgstr "turecki"
+
+#: addon/globalPlugins/TiendaNVDA/ajustes.py:190
+msgid "Ucraniano"
+msgstr "ukraiński"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:79
+msgid ""
+"\n"
+"Descarga completada correctamente."
+msgstr ""
+"\n"
+"Pobieranie zakończone pomyślnie."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:84
+msgid ""
+"\n"
+"Error en la descarga tras varios intentos."
+msgstr ""
+"\n"
+"Błąd pobierania po kilku próbach."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:98
+msgid "Actualizaciones disponibles"
+msgstr "Dostępne aktualizacje"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:114
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:353
+msgid "&Seleccionar todo"
+msgstr "&Zaznacz wszystko"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:115
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:354
+msgid "&Deseleccionar todo"
+msgstr "&Odznacz wszystko"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:143
+msgid "Seleccione al menos una actualización."
+msgstr "Wybierz co najmniej jedną aktualizację."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:167
+msgid "Actualizando complementos"
+msgstr "Aktualizowanie dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:182
+msgid "Progreso descarga:"
+msgstr "Postęp pobierania:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:184
+msgid "Progreso total:"
+msgstr "Całkowity postęp:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:189
+msgid "&Reiniciar NVDA"
+msgstr "&Uruchom ponownie NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:214
+msgid "Descargando: {}"
+msgstr "Pobieranie: {}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:251
+msgid "Instalando: {}"
+msgstr "Instalowanie: {}"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:269
+msgid "RESUMEN DE OPERACIÓN:\n"
+msgstr ""
+"PODSUMOWANIE OPERACJI:\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:272
+msgid "Instalados con éxito ({}):\n"
+msgstr ""
+"Zainstalowane pomyślnie ({}):\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:278
+msgid "Errores/Fallos ({}):\n"
+msgstr ""
+"Błędy/niepowodzenia ({}):\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:287
+msgid "No se procesó ningún complemento."
+msgstr "Nie przetworzono żadnego dodatku."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:293
+msgid "Operación completada. Reinicie NVDA para aplicar cambios."
+msgstr "Operacja zakończona. Uruchom ponownie NVDA, aby zastosować zmiany."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:316
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:100
+msgid ""
+"Se han realizado cambios en los complementos que requieren reiniciar NVDA "
+"para surtir efecto. ¿Desea reiniciar ahora?"
+msgstr "W dodatkach wprowadzono zmiany, które wymagają ponownego uruchomienia NVDA. Czy uruchomić ponownie teraz?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:317
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:101
+msgid "Reiniciar NVDA"
+msgstr "Uruchom ponownie NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:328
+msgid "Restaurar desde Backup"
+msgstr "Przywróć z kopii zapasowej"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:338
+msgid "&Seleccione complementos a restaurar:"
+msgstr "&Wybierz dodatki do przywrócenia:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:344
+msgid "&Información de la versión encontrada:"
+msgstr "&Informacje o znalezionej wersji:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:360
+msgid "&Instalar seleccionados"
+msgstr "&Instaluj zaznaczone"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:376
+msgid "Buscando mejores versiones en los servidores..."
+msgstr "Wyszukiwanie najlepszych wersji na serwerach..."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:410
+msgid "Búsqueda de backup finalizada."
+msgstr "Wyszukiwanie kopii zapasowej zakończone."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:413
+msgid "Error al procesar el backup"
+msgstr "Błąd podczas przetwarzania kopii zapasowej"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:423
+msgid "(No encontrado en servidores)"
+msgstr "(Nie znaleziono na serwerach)"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:436
+msgid "Este complemento no se ha encontrado en los servidores actuales."
+msgstr "Tego dodatku nie znaleziono na bieżących serwerach."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:439
+msgid "FUENTE: NVDA.ES\n"
+msgstr ""
+"ŹRÓDŁO: NVDA.ES\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:443
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:453
+msgid "Versión disponible: {}\n"
+msgstr ""
+"Dostępna wersja: {}\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:445
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:455
+msgid "Descripción:"
+msgstr "Opis:"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:449
+msgid "FUENTE: TIENDA OFICIAL\n"
+msgstr ""
+"ŹRÓDŁO: OFICJALNY SKLEP\n"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:472
+msgid "Seleccione al menos un complemento."
+msgstr "Wybierz co najmniej jeden dodatek."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:472
+msgid "Aviso"
+msgstr "Uwaga"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_actualizaciones.py:499
+#, python-format
+msgid ""
+"Los siguientes complementos no son compatibles:\n"
+"\n"
+"%s\n"
+"\n"
+"¿Desea intentar instalarlos de todos modos?"
+msgstr ""
+"Następujące dodatki nie są zgodne:\n"
+"\n"
+"%s\n"
+"\n"
+"Czy mimo to chcesz spróbować je zainstalować?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:43
+msgid "Copiado al portapapeles"
+msgstr "Skopiowano do schowka"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:70
+msgid "¿Está seguro de que desea desinstalar este complemento?"
+msgstr "Czy na pewno chcesz odinstalować ten dodatek?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:77
+msgid ""
+"Este complemento no es compatible con su versión de NVDA. ¿Desea intentar "
+"habilitarlo de todos modos?"
+msgstr "Ten dodatek nie jest zgodny z Twoją wersją NVDA. Czy mimo to chcesz spróbować go włączyć?"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:78
+msgid "Advertencia de compatibilidad"
+msgstr "Ostrzeżenie o zgodności"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:87
+msgid ""
+"Operación realizada con éxito. Algunos cambios requieren reiniciar NVDA."
+msgstr "Operacja wykonana pomyślnie. Niektóre zmiany wymagają ponownego uruchomienia NVDA."
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:124
+msgid "Habilitar complemento"
+msgstr "Włącz dodatek"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:127
+msgid "Deshabilitar complemento"
+msgstr "Wyłącz dodatek"
+
+#. Desinstalar
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:131
+msgid "Desinstalar complemento"
+msgstr "Odinstaluj dodatek"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:139
+#: addon/globalPlugins/TiendaNVDA/__init__.py:146
+#: addon/globalPlugins/TiendaNVDA/__init__.py:233
+msgid "Empaquetador de complementos"
+msgstr "Pakowarka dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:149
+msgid "Ver documentación"
+msgstr "Zobacz dokumentację"
+
+#: addon/globalPlugins/TiendaNVDA/dialogos_comunes.py:159
+#: addon/globalPlugins/TiendaNVDA/__init__.py:237
+msgid "Seleccione un directorio para guardar:"
+msgstr "Wybierz katalog zapisu:"
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:162
+msgid "El complemento está instalado y activo."
+msgstr "Dodatek jest zainstalowany i aktywny."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:163
+msgid "Hay una actualización disponible para este complemento."
+msgstr "Dostępna jest aktualizacja tego dodatku."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:164
+msgid ""
+"Hay una actualización disponible pero no es compatible con su versión de "
+"NVDA."
+msgstr "Dostępna jest aktualizacja, ale nie jest zgodna z Twoją wersją NVDA."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:165
+msgid "El complemento está instalado pero deshabilitado."
+msgstr "Dodatek jest zainstalowany, ale wyłączony."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:166
+msgid "El complemento está pendiente de eliminar. Requiere reiniciar NVDA."
+msgstr "Dodatek oczekuje na usunięcie. Wymaga ponownego uruchomienia NVDA."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:167
+msgid ""
+"El complemento está instalado pero bloqueado por incompatibilidad con su "
+"versión de NVDA."
+msgstr "Dodatek jest zainstalowany, ale zablokowany z powodu niezgodności z Twoją wersją NVDA."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:168
+msgid ""
+"El complemento no es compatible con su versión de NVDA y no está instalado."
+msgstr "Dodatek nie jest zgodny z Twoją wersją NVDA i nie jest zainstalowany."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:169
+msgid "El complemento no está instalado."
+msgstr "Dodatek nie jest zainstalowany."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:171
+msgid "Estado desconocido."
+msgstr "Nieznany stan."
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:174
+msgid "Fuente: Tienda NVDA.ES (comunidad hispana)"
+msgstr "Źródło: sklep NVDA.ES (społeczność hiszpańska)"
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:175
+msgid "Fuente: Tienda Oficial de NVDA"
+msgstr "Źródło: oficjalny sklep NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/addon_manager.py:176
+msgid "Fuente: Tienda Unificada de Complementos"
+msgstr "Źródło: ujednolicony sklep dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:49
+msgid "Necesita reiniciar NVDA para aplicar las actualizaciones."
+msgstr "Musisz ponownie uruchomić NVDA, aby zastosować aktualizacje."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:76
+msgid "Se encontraron {} actualizaciones."
+msgstr "Znaleziono {} aktualizacji."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:76
+msgid "Se encontró una actualización."
+msgstr "Znaleziono jedną aktualizację."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:79
+msgid ""
+"\n"
+"- NVDA.ES ({}): {}"
+msgstr ""
+"\n"
+"- NVDA.ES ({}): {}"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:81
+msgid ""
+"\n"
+"- Tienda Oficial ({}): {}"
+msgstr ""
+"\n"
+"- Oficjalny sklep ({}): {}"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:82
+msgid ""
+"\n"
+"\n"
+"Ejecute Buscar actualizaciones de complementos."
+msgstr ""
+"\n"
+"\n"
+"Uruchom wyszukiwanie aktualizacji dodatków."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:83
+msgid "Tienda NVDA: Actualizaciones"
+msgstr "Sklep NVDA: aktualizacje"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:109
+msgid "No se pudieron cargar las librerías necesarias para la Tienda"
+msgstr "Nie udało się wczytać bibliotek wymaganych przez sklep"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:125
+msgid "Listado de complementos NVDA.ES"
+msgstr "Lista dodatków NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:127
+msgid "Buscar actualizaciones NVDA.ES"
+msgstr "Szukaj aktualizacji NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:129
+#: addon/globalPlugins/TiendaNVDA/__init__.py:269
+msgid "Tienda NVDA.ES"
+msgstr "Sklep NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:133
+msgid "Listado de complementos oficiales"
+msgstr "Lista oficjalnych dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:135
+msgid "Buscar actualizaciones oficiales"
+msgstr "Szukaj oficjalnych aktualizacji"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:141
+msgid "Tienda Unificada (Todas las fuentes)"
+msgstr "Ujednolicony sklep (wszystkie źródła)"
+
+#. Documentación
+#: addon/globalPlugins/TiendaNVDA/__init__.py:150
+msgid "Documentación del complemento"
+msgstr "Dokumentacja dodatku"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:155
+msgid "Inicio del complemento cancelado."
+msgstr "Uruchomienie dodatku anulowane."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:197
+msgid "Ya hay una instancia de la Tienda NVDA abierta."
+msgstr "Jedno okno sklepu NVDA jest już otwarte."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:201
+msgid "Muestra la ventana con todos los complementos de NVDA.ES"
+msgstr "Pokazuje okno ze wszystkimi dodatkami NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:205
+msgid "Busca actualizaciones de los complementos instalados en NVDA.ES"
+msgstr "Wyszukuje aktualizacje dodatków zainstalowanych z NVDA.ES"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:209
+msgid "Muestra la ventana con todos los complementos de la tienda oficial"
+msgstr "Pokazuje okno ze wszystkimi dodatkami z oficjalnego sklepu"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:213
+msgid "Busca actualizaciones de los complementos oficiales"
+msgstr "Wyszukuje aktualizacje oficjalnych dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:217
+msgid "Muestra la tienda unificada con todas las fuentes de complementos"
+msgstr "Pokazuje ujednolicony sklep ze wszystkimi źródłami dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:230
+msgid "No hay complementos instalados."
+msgstr "Brak zainstalowanych dodatków."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:233
+msgid "Seleccione un complemento para empaquetar:"
+msgstr "Wybierz dodatek do spakowania:"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:251
+msgid ""
+"El complemento falló al iniciar NVDA.\n"
+"Reinice NVDA para intentar solucionar el problema."
+msgstr ""
+"Dodatek nie uruchomił się poprawnie wraz z NVDA.\n"
+"Uruchom ponownie NVDA, aby spróbować rozwiązać problem."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:275
+msgid "Seleccione un servidor de complementos"
+msgstr "Wybierz serwer dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:283
+msgid "&Gestionar Servidores de complementos"
+msgstr "&Zarządzaj serwerami dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:299
+msgid "Habilitar tienda oficial de NVDA"
+msgstr "Włącz oficjalny sklep NVDA"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:304
+msgid "Permitir complementos incompatibles de la tienda oficial"
+msgstr "Zezwalaj na niezgodne dodatki z oficjalnego sklepu"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:314
+msgid "Actualizaciones"
+msgstr "Aktualizacje"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:320
+msgid "Activar comprobación automática de actualizaciones"
+msgstr "Włącz automatyczne sprawdzanie aktualizacji"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:327
+msgid "Tiempo para comprobar actualizaciones:"
+msgstr "Interwał sprawdzania aktualizacji:"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:339
+msgid "Incluir actualizaciones de la tienda oficial"
+msgstr "Uwzględniaj aktualizacje z oficjalnego sklepu"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:349
+msgid "Traducción"
+msgstr "Tłumaczenie"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:355
+msgid "Activar traductor para descripciones"
+msgstr "Włącz tłumacza opisów"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:362
+msgid "Idioma para traducir descripciones:"
+msgstr "Język tłumaczenia opisów:"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:379
+msgid "Opciones Generales"
+msgstr "Opcje ogólne"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:385
+msgid "Ordenar complementos alfabéticamente"
+msgstr "Sortuj dodatki alfabetycznie"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:390
+msgid "Instalar complementos después de descargar"
+msgstr "Instaluj dodatki po pobraniu"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:395
+msgid "Instalar en silencio (pide reiniciar al finalizar)"
+msgstr "Instaluj po cichu (po zakończeniu prosi o ponowne uruchomienie)"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:400
+msgid "Habilitar caché de servidores (Mejora la velocidad de carga)"
+msgstr "Włącz pamięć podręczną serwerów (przyspiesza ładowanie)"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:407
+msgid "Actualizar caché cada:"
+msgstr "Odświeżaj pamięć podręczną co:"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:419
+msgid "Usar caché para traducciones (Mejora el rendimiento)"
+msgstr "Używaj pamięci podręcznej dla tłumaczeń (poprawia wydajność)"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:424
+msgid "Habilitar modo offline (Caché de listas de la tienda)"
+msgstr "Włącz tryb offline (pamięć podręczna list sklepu)"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:429
+msgid "&Crear Backup de complementos"
+msgstr "&Utwórz kopię zapasową dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:430
+msgid "&Restaurar desde Backup"
+msgstr "&Przywróć z kopii zapasowej"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:444
+msgid "Complementos instalados que hay en el servidor:"
+msgstr "Zainstalowane dodatki dostępne na serwerze:"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:459
+#: addon/globalPlugins/TiendaNVDA/__init__.py:564
+#: addon/globalPlugins/TiendaNVDA/__init__.py:610
+msgid "No se pudo tener acceso al servidor"
+msgstr "Nie udało się uzyskać dostępu do serwera"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:463
+#: addon/globalPlugins/TiendaNVDA/__init__.py:608
+msgid "Sin complementos compatibles"
+msgstr "Brak zgodnych dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:473
+#: addon/globalPlugins/TiendaNVDA/__init__.py:623
+#: addon/globalPlugins/TiendaNVDA/__init__.py:636
+msgid "Descartar actualizaciones"
+msgstr "Odrzuć aktualizacje"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:653
+msgid ""
+"Ya hay una instancia de la Tienda NVDA abierta.\n"
+"\n"
+"Para gestionar los servidores es necesario que la Tienda este cerrada."
+msgstr ""
+"Jedno okno sklepu NVDA jest już otwarte.\n"
+"\n"
+"Aby zarządzać serwerami, sklep musi być zamknięty."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:674
+msgid "Guardar copia de seguridad de complementos"
+msgstr "Zapisz kopię zapasową dodatków"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:685
+msgid "Copia de seguridad guardada con éxito en: {}"
+msgstr "Kopia zapasowa została pomyślnie zapisana w: {}"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:687
+msgid "Error al crear la copia de seguridad: {}"
+msgstr "Błąd podczas tworzenia kopii zapasowej: {}"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:692
+msgid "Seleccionar archivo de copia de seguridad"
+msgstr "Wybierz plik kopii zapasowej"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:706
+msgid "El archivo seleccionado no es una copia de seguridad válida."
+msgstr "Wybrany plik nie jest prawidłową kopią zapasową."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:709
+msgid ""
+"¿Desea restaurar los complementos desde el archivo seleccionado? Esto abrirá "
+"el asistente de instalación por lotes."
+msgstr "Czy chcesz przywrócić dodatki z wybranego pliku? Spowoduje to otwarcie kreatora instalacji zbiorczej."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:710
+msgid "Restaurar"
+msgstr "Przywróć"
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:718
+msgid "Cierre la tienda antes de proceder con la restauración."
+msgstr "Zamknij sklep przed rozpoczęciem przywracania."
+
+#: addon/globalPlugins/TiendaNVDA/__init__.py:720
+msgid "Error al cargar el backup: {}"
+msgstr "Błąd podczas wczytywania kopii zapasowej: {}"
+
+#. Add-on summary/title, usually the user visible name of the add-on
+#. Translators: Summary/title for this add-on
+#. to be shown on installation and add-on information found in add-on store
+#: buildVars.py:21
+msgid "Tienda de Complementos para NVDA"
+msgstr "Sklep z dodatkami dla NVDA"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-on store
+#: buildVars.py:24
+msgid ""
+"Tienda Unificada de Complementos para NVDA.\n"
+"Integra la tienda de NVDA.ES y la tienda oficial de NV Access en una única "
+"interfaz.\n"
+"Características: indicadores de estado, gestión local (deshabilitar/"
+"eliminar), backup/restauración,\n"
+"modo offline, traducción con caché, reintentos de descarga, comprobación de "
+"dependencias\n"
+"y empaquetador de complementos."
+msgstr ""
+"Ujednolicony sklep dodatków dla NVDA.\n"
+"Łączy sklep NVDA.ES i oficjalny sklep NV Access w jednym interfejsie.\n"
+"Funkcje: wskaźniki stanu, lokalne zarządzanie (wyłączanie/usuwanie), kopia zapasowa/przywracanie,\n"
+"tryb offline, tłumaczenie z pamięcią podręczną, ponawianie pobierania, sprawdzanie zależności\n"
+"i pakowarka dodatków."
+
+#. Brief changelog for this version
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:33
+msgid ""
+"Primera versión de la Tienda Unificada.\n"
+"Integración completa de NVDA.ES y tienda oficial.\n"
+"Nuevo sistema de caché multinivel, backup/restauración y modo offline."
+msgstr ""
+"Pierwsza wersja ujednoliconego sklepu.\n"
+"Pełna integracja NVDA.ES i oficjalnego sklepu.\n"
+"Nowy wielopoziomowy system pamięci podręcznej, kopia zapasowa/przywracanie i tryb offline."


### PR DESCRIPTION
Adds Polish localization for TiendaNVDA.\n\nChanges:\n- add Polish gettext catalog: addon/locale/pl/LC_MESSAGES/nvda.po\n- add Polish documentation: addon/doc/pl/readme.md\n\nValidation performed locally:\n- checked 287 translated gettext entries\n- checked for empty msgstr values\n- checked placeholder consistency for {}, named format fields, and printf-style placeholders\n- ran git diff --check