### PR TITLE
Credit Polish translation in changelog

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,8 @@ y empaquetador de complementos."""),
 	# Translators: what's new content for the add-on version to be shown in the add-on store
 	addon_changelog=_("""*Agregado un actualizador silencioso de idiomas del complemento (en fase beta).
 * Agregado idioma ruso (Valentín N. Kupriyanov).
-* Agregado idioma turco (Umut Korkmaz)."""),
+* Agregado idioma turco (Umut Korkmaz).
+* Agregado idioma polaco (Kazimierz Parzych)."""),
 	# Author(s)
 	addon_author="Héctor J. Benítez Corredera <xebolax@gmail.com>",
 	# URL for the add-on documentation support

--- a/changelog.md
+++ b/changelog.md
@@ -2,3 +2,4 @@
 
 *Corregido  el actualizador silencioso de idiomas del complemento (en fase beta)
 Agregadas las mejoras de Javi Dominguez (PR #1 y #2)
+Agregado idioma polaco (Kazimierz Parzych)


### PR DESCRIPTION
Adds the Polish translation credit to the changelog metadata so it is visible in the add-on information/changelog sources, matching the existing collaborators section in readme.md.\n\nChanges:\n- add Polish language credit to buildVars.py addon_changelog\n- add Polish language credit to changelog.md\n\nValidation:\n- ran git diff --check